### PR TITLE
feat: integrate osxphotos library for Photos library access

### DIFF
--- a/src/video_converter/extractors/__init__.py
+++ b/src/video_converter/extractors/__init__.py
@@ -1,0 +1,25 @@
+"""Video extractors package.
+
+This package provides modules for extracting videos from various sources,
+primarily the macOS Photos library.
+"""
+
+from video_converter.extractors.photos_extractor import (
+    MediaType,
+    PhotosAccessDeniedError,
+    PhotosLibrary,
+    PhotosLibraryError,
+    PhotosLibraryNotFoundError,
+    PhotosVideoInfo,
+    get_permission_instructions,
+)
+
+__all__ = [
+    "MediaType",
+    "PhotosAccessDeniedError",
+    "PhotosLibrary",
+    "PhotosLibraryError",
+    "PhotosLibraryNotFoundError",
+    "PhotosVideoInfo",
+    "get_permission_instructions",
+]

--- a/src/video_converter/extractors/photos_extractor.py
+++ b/src/video_converter/extractors/photos_extractor.py
@@ -1,0 +1,473 @@
+"""Photos library integration module.
+
+This module provides read-only access to the macOS Photos library
+for querying video assets using the osxphotos library.
+
+SDS Reference: SDS-P01-004
+SRS Reference: SRS-301 (Photos Library Integration)
+
+Example:
+    >>> library = PhotosLibrary()
+    >>> if library.check_permissions():
+    ...     print(f"Found {library.get_video_count()} videos")
+    ... else:
+    ...     print("Access denied")
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import osxphotos
+
+logger = logging.getLogger(__name__)
+
+
+class PhotosLibraryError(Exception):
+    """Base exception for Photos library operations."""
+
+
+class PhotosAccessDeniedError(PhotosLibraryError):
+    """Raised when access to Photos library is denied.
+
+    This typically occurs when the application doesn't have
+    Full Disk Access permission in System Settings.
+    """
+
+    def __init__(self, message: str | None = None) -> None:
+        """Initialize with optional custom message.
+
+        Args:
+            message: Custom error message. If None, uses default.
+        """
+        if message is None:
+            message = (
+                "Photos library access denied. "
+                "Grant Full Disk Access permission in System Settings."
+            )
+        super().__init__(message)
+
+
+class PhotosLibraryNotFoundError(PhotosLibraryError):
+    """Raised when Photos library cannot be found."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        """Initialize with optional library path.
+
+        Args:
+            path: Path that was attempted if custom path was specified.
+        """
+        if path:
+            message = f"Photos library not found at: {path}"
+        else:
+            message = "Default Photos library not found"
+        super().__init__(message)
+
+
+class MediaType(Enum):
+    """Media types available in Photos library.
+
+    Attributes:
+        VIDEO: Video files (mov, mp4, etc.).
+        PHOTO: Photo files (jpg, heic, etc.).
+        ALL: All media types.
+    """
+
+    VIDEO = "video"
+    PHOTO = "photo"
+    ALL = "all"
+
+
+@dataclass
+class PhotosVideoInfo:
+    """Information about a video in the Photos library.
+
+    Attributes:
+        uuid: Unique identifier for the asset in Photos.
+        filename: Original filename of the video.
+        path: Path to the video file (may be None if in iCloud).
+        date: Creation date of the video.
+        date_modified: Last modification date.
+        duration: Video duration in seconds.
+        favorite: Whether the video is marked as favorite.
+        hidden: Whether the video is hidden.
+        in_cloud: Whether the video is stored in iCloud.
+        location: GPS coordinates (latitude, longitude) if available.
+        albums: List of album names containing this video.
+    """
+
+    uuid: str
+    filename: str
+    path: Path | None
+    date: datetime | None
+    date_modified: datetime | None
+    duration: float
+    favorite: bool = False
+    hidden: bool = False
+    in_cloud: bool = False
+    location: tuple[float, float] | None = None
+    albums: list[str] = field(default_factory=list)
+
+    @property
+    def is_available_locally(self) -> bool:
+        """Check if the video file is available locally.
+
+        Returns:
+            True if the file exists locally, False if in iCloud only.
+        """
+        if self.path is None:
+            return False
+        return self.path.exists()
+
+
+class PhotosLibrary:
+    """Interface to macOS Photos library via osxphotos.
+
+    This class provides a high-level interface for querying videos
+    from the macOS Photos library. It handles library initialization,
+    permission checking, and provides caching for performance.
+
+    SDS Reference: SDS-P01-004
+
+    Example:
+        >>> library = PhotosLibrary()
+        >>> if library.check_permissions():
+        ...     videos = library.get_videos()
+        ...     for video in videos:
+        ...         print(f"{video.filename}: {video.duration}s")
+
+    Attributes:
+        library_path: Path to the Photos library (None for default).
+    """
+
+    # Default Photos library location
+    DEFAULT_LIBRARY_PATH = Path.home() / "Pictures" / "Photos Library.photoslibrary"
+
+    def __init__(self, library_path: Path | None = None) -> None:
+        """Initialize Photos library connection.
+
+        Args:
+            library_path: Custom library path. None uses the default
+                system Photos library.
+
+        Raises:
+            PhotosLibraryNotFoundError: If specified library path doesn't exist.
+        """
+        self._library_path = library_path
+        self._db: osxphotos.PhotosDB | None = None
+        self._initialized: bool = False
+        self._permission_checked: bool = False
+        self._has_permission: bool = False
+
+        # Validate custom path if provided
+        if library_path is not None and not library_path.exists():
+            raise PhotosLibraryNotFoundError(library_path)
+
+    @property
+    def library_path(self) -> Path:
+        """Get the Photos library path.
+
+        Returns:
+            Path to the Photos library (default or custom).
+        """
+        if self._library_path is not None:
+            return self._library_path
+        return self.DEFAULT_LIBRARY_PATH
+
+    @property
+    def db(self) -> osxphotos.PhotosDB:
+        """Get the PhotosDB instance (lazy-loaded).
+
+        Returns:
+            osxphotos.PhotosDB instance.
+
+        Raises:
+            PhotosAccessDeniedError: If access is denied.
+            PhotosLibraryNotFoundError: If library cannot be found.
+        """
+        if self._db is None:
+            self._db = self._initialize_db()
+        return self._db
+
+    def _initialize_db(self) -> osxphotos.PhotosDB:
+        """Initialize the PhotosDB connection.
+
+        Returns:
+            Initialized PhotosDB instance.
+
+        Raises:
+            PhotosAccessDeniedError: If access is denied.
+            PhotosLibraryNotFoundError: If library cannot be found.
+        """
+        import osxphotos
+
+        logger.info("Initializing Photos library connection")
+
+        try:
+            if self._library_path is not None:
+                db = osxphotos.PhotosDB(dbfile=str(self._library_path))
+            else:
+                db = osxphotos.PhotosDB()
+
+            self._initialized = True
+            logger.info(f"Photos library opened: {db.library_path}")
+            return db
+
+        except FileNotFoundError as e:
+            logger.error(f"Photos library not found: {e}")
+            raise PhotosLibraryNotFoundError(self._library_path) from e
+        except PermissionError as e:
+            logger.error(f"Photos library access denied: {e}")
+            raise PhotosAccessDeniedError() from e
+        except Exception as e:
+            # osxphotos may raise various exceptions for permission issues
+            error_str = str(e).lower()
+            if "permission" in error_str or "access" in error_str:
+                logger.error(f"Photos library access denied: {e}")
+                raise PhotosAccessDeniedError(str(e)) from e
+            logger.error(f"Failed to open Photos library: {e}")
+            raise PhotosLibraryError(f"Failed to open Photos library: {e}") from e
+
+    def check_permissions(self) -> bool:
+        """Check if we have access to the Photos library.
+
+        This method attempts to open the Photos library to verify
+        permissions. The result is cached for subsequent calls.
+
+        Returns:
+            True if access is granted, False otherwise.
+        """
+        if self._permission_checked:
+            return self._has_permission
+
+        try:
+            # Try to access the library
+            _ = self.db.library_path
+            self._has_permission = True
+            logger.info("Photos library permission check passed")
+        except PhotosAccessDeniedError:
+            self._has_permission = False
+            logger.warning("Photos library permission denied")
+        except PhotosLibraryNotFoundError:
+            self._has_permission = False
+            logger.warning("Photos library not found")
+        except Exception as e:
+            self._has_permission = False
+            logger.warning(f"Photos library permission check failed: {e}")
+
+        self._permission_checked = True
+        return self._has_permission
+
+    def get_library_info(self) -> dict[str, str | int]:
+        """Get information about the Photos library.
+
+        Returns:
+            Dictionary with library information:
+                - path: Library path
+                - photo_count: Total number of photos
+                - video_count: Total number of videos
+
+        Raises:
+            PhotosAccessDeniedError: If access is denied.
+        """
+        return {
+            "path": str(self.db.library_path),
+            "photo_count": len(self.db.photos(media_type=["photo"])),
+            "video_count": len(self.db.photos(media_type=["video"])),
+        }
+
+    def get_video_count(self) -> int:
+        """Get the total number of videos in the library.
+
+        Returns:
+            Number of videos in the Photos library.
+
+        Raises:
+            PhotosAccessDeniedError: If access is denied.
+        """
+        return len(self.db.photos(media_type=["video"]))
+
+    def get_videos(
+        self,
+        *,
+        from_date: datetime | None = None,
+        to_date: datetime | None = None,
+        albums: list[str] | None = None,
+        favorites_only: bool = False,
+        include_hidden: bool = False,
+    ) -> list[PhotosVideoInfo]:
+        """Get videos from the Photos library.
+
+        Args:
+            from_date: Only include videos created on or after this date.
+            to_date: Only include videos created on or before this date.
+            albums: Filter by album names (None for all albums).
+            favorites_only: Only include favorite videos.
+            include_hidden: Include hidden videos.
+
+        Returns:
+            List of PhotosVideoInfo objects.
+
+        Raises:
+            PhotosAccessDeniedError: If access is denied.
+        """
+        logger.debug(
+            f"Querying videos: from_date={from_date}, to_date={to_date}, "
+            f"albums={albums}, favorites={favorites_only}, hidden={include_hidden}"
+        )
+
+        # Build query parameters
+        query_params: dict[str, list[str] | datetime | bool] = {
+            "media_type": ["video"],
+        }
+
+        if from_date is not None:
+            query_params["from_date"] = from_date
+
+        if to_date is not None:
+            query_params["to_date"] = to_date
+
+        # Query videos
+        photos = self.db.photos(**query_params)  # type: ignore[arg-type]
+
+        # Apply additional filters
+        videos: list[PhotosVideoInfo] = []
+        for photo in photos:
+            # Skip hidden if not requested
+            if photo.hidden and not include_hidden:
+                continue
+
+            # Skip non-favorites if favorites_only
+            if favorites_only and not photo.favorite:
+                continue
+
+            # Filter by albums if specified
+            if albums is not None:
+                photo_albums = [a.title for a in photo.albums]
+                if not any(album in photo_albums for album in albums):
+                    continue
+
+            video_info = self._convert_to_video_info(photo)
+            videos.append(video_info)
+
+        logger.info(f"Found {len(videos)} videos matching criteria")
+        return videos
+
+    def get_video_by_uuid(self, uuid: str) -> PhotosVideoInfo | None:
+        """Get a specific video by its UUID.
+
+        Args:
+            uuid: The UUID of the video asset.
+
+        Returns:
+            PhotosVideoInfo if found, None otherwise.
+
+        Raises:
+            PhotosAccessDeniedError: If access is denied.
+        """
+        photos = self.db.photos(uuid=[uuid])
+        if not photos:
+            return None
+
+        return self._convert_to_video_info(photos[0])
+
+    def _convert_to_video_info(self, photo: osxphotos.PhotoInfo) -> PhotosVideoInfo:
+        """Convert osxphotos PhotoInfo to PhotosVideoInfo.
+
+        Args:
+            photo: osxphotos PhotoInfo object.
+
+        Returns:
+            PhotosVideoInfo with extracted information.
+        """
+        # Get path (may be None for iCloud-only files)
+        path: Path | None = None
+        if photo.path:
+            path = Path(photo.path)
+
+        # Get location
+        location: tuple[float, float] | None = None
+        if photo.location and photo.location[0] is not None:
+            location = (photo.location[0], photo.location[1])
+
+        # Get album names
+        albums = [album.title for album in photo.albums if album.title]
+
+        return PhotosVideoInfo(
+            uuid=photo.uuid,
+            filename=photo.original_filename,
+            path=path,
+            date=photo.date,
+            date_modified=photo.date_modified,
+            duration=photo.duration or 0.0,
+            favorite=photo.favorite,
+            hidden=photo.hidden,
+            in_cloud=photo.iscloudasset,
+            location=location,
+            albums=albums,
+        )
+
+    def close(self) -> None:
+        """Close the Photos library connection.
+
+        This releases any resources held by the connection.
+        The library can be reopened by accessing the db property.
+        """
+        self._db = None
+        self._initialized = False
+        self._permission_checked = False
+        logger.debug("Photos library connection closed")
+
+    def __enter__(self) -> PhotosLibrary:
+        """Context manager entry.
+
+        Returns:
+            Self for context manager usage.
+        """
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object | None,
+    ) -> None:
+        """Context manager exit.
+
+        Args:
+            exc_type: Exception type if an exception occurred.
+            exc_val: Exception value if an exception occurred.
+            exc_tb: Exception traceback if an exception occurred.
+        """
+        self.close()
+
+
+def get_permission_instructions() -> str:
+    """Get instructions for granting Photos library access.
+
+    Returns:
+        Multi-line string with detailed instructions for granting
+        Full Disk Access permission.
+    """
+    return """
+Photos Library Access Denied
+
+Video Converter needs access to your Photos library.
+
+To grant access:
+1. Open System Settings → Privacy & Security → Full Disk Access
+2. Click the + button
+3. Navigate to: /Applications/Utilities/Terminal.app
+   (or the application running this script)
+4. Add it to the list and enable the toggle
+5. Restart the application and try again
+
+Quick access command:
+  open "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
+""".strip()

--- a/tests/unit/test_photos_extractor.py
+++ b/tests/unit/test_photos_extractor.py
@@ -1,0 +1,452 @@
+"""Unit tests for photos_extractor module."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_converter.extractors.photos_extractor import (
+    MediaType,
+    PhotosAccessDeniedError,
+    PhotosLibrary,
+    PhotosLibraryNotFoundError,
+    PhotosVideoInfo,
+    get_permission_instructions,
+)
+
+
+class TestPhotosVideoInfo:
+    """Tests for PhotosVideoInfo dataclass."""
+
+    def test_video_info_creation(self) -> None:
+        """Test creating a video info object."""
+        video = PhotosVideoInfo(
+            uuid="ABC123",
+            filename="vacation.mov",
+            path=Path("/path/to/video.mov"),
+            date=datetime(2024, 1, 15),
+            date_modified=datetime(2024, 1, 16),
+            duration=120.5,
+            favorite=True,
+            hidden=False,
+            in_cloud=False,
+            location=(37.7749, -122.4194),
+            albums=["Vacation 2024", "Favorites"],
+        )
+
+        assert video.uuid == "ABC123"
+        assert video.filename == "vacation.mov"
+        assert video.duration == 120.5
+        assert video.favorite is True
+        assert video.location == (37.7749, -122.4194)
+        assert "Vacation 2024" in video.albums
+
+    def test_is_available_locally_with_existing_path(self, tmp_path: Path) -> None:
+        """Test is_available_locally with existing file."""
+        video_file = tmp_path / "test.mov"
+        video_file.touch()
+
+        video = PhotosVideoInfo(
+            uuid="ABC123",
+            filename="test.mov",
+            path=video_file,
+            date=None,
+            date_modified=None,
+            duration=60.0,
+        )
+
+        assert video.is_available_locally is True
+
+    def test_is_available_locally_with_nonexistent_path(self) -> None:
+        """Test is_available_locally with non-existent file."""
+        video = PhotosVideoInfo(
+            uuid="ABC123",
+            filename="test.mov",
+            path=Path("/nonexistent/path.mov"),
+            date=None,
+            date_modified=None,
+            duration=60.0,
+        )
+
+        assert video.is_available_locally is False
+
+    def test_is_available_locally_with_none_path(self) -> None:
+        """Test is_available_locally when path is None (iCloud only)."""
+        video = PhotosVideoInfo(
+            uuid="ABC123",
+            filename="test.mov",
+            path=None,
+            date=None,
+            date_modified=None,
+            duration=60.0,
+            in_cloud=True,
+        )
+
+        assert video.is_available_locally is False
+
+    def test_default_values(self) -> None:
+        """Test default values for optional fields."""
+        video = PhotosVideoInfo(
+            uuid="ABC123",
+            filename="test.mov",
+            path=None,
+            date=None,
+            date_modified=None,
+            duration=0.0,
+        )
+
+        assert video.favorite is False
+        assert video.hidden is False
+        assert video.in_cloud is False
+        assert video.location is None
+        assert video.albums == []
+
+
+class TestMediaType:
+    """Tests for MediaType enum."""
+
+    def test_media_type_values(self) -> None:
+        """Test MediaType enum values."""
+        assert MediaType.VIDEO.value == "video"
+        assert MediaType.PHOTO.value == "photo"
+        assert MediaType.ALL.value == "all"
+
+
+class TestPhotosLibraryExceptions:
+    """Tests for Photos library exceptions."""
+
+    def test_photos_access_denied_error_default_message(self) -> None:
+        """Test PhotosAccessDeniedError with default message."""
+        error = PhotosAccessDeniedError()
+        assert "access denied" in str(error).lower()
+        assert "Full Disk Access" in str(error)
+
+    def test_photos_access_denied_error_custom_message(self) -> None:
+        """Test PhotosAccessDeniedError with custom message."""
+        error = PhotosAccessDeniedError("Custom error message")
+        assert str(error) == "Custom error message"
+
+    def test_photos_library_not_found_error_with_path(self) -> None:
+        """Test PhotosLibraryNotFoundError with path."""
+        path = Path("/custom/library.photoslibrary")
+        error = PhotosLibraryNotFoundError(path)
+        assert "/custom/library.photoslibrary" in str(error)
+
+    def test_photos_library_not_found_error_without_path(self) -> None:
+        """Test PhotosLibraryNotFoundError without path."""
+        error = PhotosLibraryNotFoundError()
+        assert "Default" in str(error)
+
+
+class TestPhotosLibrary:
+    """Tests for PhotosLibrary class."""
+
+    def test_init_with_default_path(self) -> None:
+        """Test initialization with default library path."""
+        library = PhotosLibrary()
+        expected_path = Path.home() / "Pictures" / "Photos Library.photoslibrary"
+        assert library.library_path == expected_path
+
+    def test_init_with_custom_path(self, tmp_path: Path) -> None:
+        """Test initialization with custom library path."""
+        custom_lib = tmp_path / "Custom.photoslibrary"
+        custom_lib.mkdir()
+
+        library = PhotosLibrary(library_path=custom_lib)
+        assert library.library_path == custom_lib
+
+    def test_init_with_nonexistent_path_raises_error(self) -> None:
+        """Test that non-existent path raises PhotosLibraryNotFoundError."""
+        with pytest.raises(PhotosLibraryNotFoundError):
+            PhotosLibrary(library_path=Path("/nonexistent/path.photoslibrary"))
+
+    @patch("video_converter.extractors.photos_extractor.osxphotos")
+    def test_db_property_lazy_loading(self, mock_osxphotos: MagicMock) -> None:
+        """Test that db property lazy-loads the database."""
+        mock_db = MagicMock()
+        mock_osxphotos.PhotosDB.return_value = mock_db
+
+        library = PhotosLibrary()
+        # First access should initialize
+        _ = library.db
+        mock_osxphotos.PhotosDB.assert_called_once()
+
+        # Second access should use cached instance
+        _ = library.db
+        mock_osxphotos.PhotosDB.assert_called_once()
+
+    @patch("video_converter.extractors.photos_extractor.osxphotos")
+    def test_db_property_with_custom_path(self, mock_osxphotos: MagicMock, tmp_path: Path) -> None:
+        """Test db property with custom library path."""
+        mock_db = MagicMock()
+        mock_osxphotos.PhotosDB.return_value = mock_db
+
+        custom_lib = tmp_path / "Custom.photoslibrary"
+        custom_lib.mkdir()
+
+        library = PhotosLibrary(library_path=custom_lib)
+        _ = library.db
+
+        mock_osxphotos.PhotosDB.assert_called_once_with(dbfile=str(custom_lib))
+
+    @patch("video_converter.extractors.photos_extractor.osxphotos")
+    def test_check_permissions_success(self, mock_osxphotos: MagicMock) -> None:
+        """Test check_permissions returns True on success."""
+        mock_db = MagicMock()
+        mock_db.library_path = "/path/to/library"
+        mock_osxphotos.PhotosDB.return_value = mock_db
+
+        library = PhotosLibrary()
+        assert library.check_permissions() is True
+
+    @patch("video_converter.extractors.photos_extractor.osxphotos")
+    def test_check_permissions_denied(self, mock_osxphotos: MagicMock) -> None:
+        """Test check_permissions returns False when access denied."""
+        mock_osxphotos.PhotosDB.side_effect = PermissionError("Access denied")
+
+        library = PhotosLibrary()
+        assert library.check_permissions() is False
+
+    @patch("video_converter.extractors.photos_extractor.osxphotos")
+    def test_check_permissions_caches_result(self, mock_osxphotos: MagicMock) -> None:
+        """Test that check_permissions caches the result."""
+        mock_db = MagicMock()
+        mock_db.library_path = "/path/to/library"
+        mock_osxphotos.PhotosDB.return_value = mock_db
+
+        library = PhotosLibrary()
+
+        # First check
+        result1 = library.check_permissions()
+        # Second check should use cached result
+        result2 = library.check_permissions()
+
+        assert result1 == result2 is True
+        # Should only call PhotosDB once due to caching
+        mock_osxphotos.PhotosDB.assert_called_once()
+
+    @patch("video_converter.extractors.photos_extractor.osxphotos")
+    def test_get_video_count(self, mock_osxphotos: MagicMock) -> None:
+        """Test get_video_count returns correct count."""
+        mock_db = MagicMock()
+        mock_db.photos.return_value = [MagicMock(), MagicMock(), MagicMock()]
+        mock_osxphotos.PhotosDB.return_value = mock_db
+
+        library = PhotosLibrary()
+        count = library.get_video_count()
+
+        assert count == 3
+        mock_db.photos.assert_called_once_with(media_type=["video"])
+
+    @patch("video_converter.extractors.photos_extractor.osxphotos")
+    def test_get_library_info(self, mock_osxphotos: MagicMock) -> None:
+        """Test get_library_info returns expected structure."""
+        mock_db = MagicMock()
+        mock_db.library_path = "/path/to/library"
+        mock_db.photos.side_effect = [
+            [MagicMock()] * 10,  # photos
+            [MagicMock()] * 5,  # videos
+        ]
+        mock_osxphotos.PhotosDB.return_value = mock_db
+
+        library = PhotosLibrary()
+        info = library.get_library_info()
+
+        assert info["path"] == "/path/to/library"
+        assert info["photo_count"] == 10
+        assert info["video_count"] == 5
+
+    @patch("video_converter.extractors.photos_extractor.osxphotos")
+    def test_get_videos_empty_library(self, mock_osxphotos: MagicMock) -> None:
+        """Test get_videos with empty library."""
+        mock_db = MagicMock()
+        mock_db.photos.return_value = []
+        mock_osxphotos.PhotosDB.return_value = mock_db
+
+        library = PhotosLibrary()
+        videos = library.get_videos()
+
+        assert videos == []
+
+    @patch("video_converter.extractors.photos_extractor.osxphotos")
+    def test_get_videos_with_filters(self, mock_osxphotos: MagicMock) -> None:
+        """Test get_videos with favorites_only filter."""
+        mock_photo1 = MagicMock()
+        mock_photo1.uuid = "uuid1"
+        mock_photo1.original_filename = "video1.mov"
+        mock_photo1.path = "/path/to/video1.mov"
+        mock_photo1.date = datetime(2024, 1, 1)
+        mock_photo1.date_modified = datetime(2024, 1, 2)
+        mock_photo1.duration = 60.0
+        mock_photo1.favorite = True
+        mock_photo1.hidden = False
+        mock_photo1.iscloudasset = False
+        mock_photo1.location = (37.0, -122.0)
+        mock_photo1.albums = []
+
+        mock_photo2 = MagicMock()
+        mock_photo2.uuid = "uuid2"
+        mock_photo2.original_filename = "video2.mov"
+        mock_photo2.favorite = False
+        mock_photo2.hidden = False
+
+        mock_db = MagicMock()
+        mock_db.photos.return_value = [mock_photo1, mock_photo2]
+        mock_osxphotos.PhotosDB.return_value = mock_db
+
+        library = PhotosLibrary()
+        videos = library.get_videos(favorites_only=True)
+
+        assert len(videos) == 1
+        assert videos[0].uuid == "uuid1"
+        assert videos[0].favorite is True
+
+    @patch("video_converter.extractors.photos_extractor.osxphotos")
+    def test_get_videos_excludes_hidden_by_default(self, mock_osxphotos: MagicMock) -> None:
+        """Test that hidden videos are excluded by default."""
+        mock_visible = MagicMock()
+        mock_visible.uuid = "visible"
+        mock_visible.original_filename = "visible.mov"
+        mock_visible.path = None
+        mock_visible.date = None
+        mock_visible.date_modified = None
+        mock_visible.duration = 30.0
+        mock_visible.favorite = False
+        mock_visible.hidden = False
+        mock_visible.iscloudasset = False
+        mock_visible.location = None
+        mock_visible.albums = []
+
+        mock_hidden = MagicMock()
+        mock_hidden.hidden = True
+
+        mock_db = MagicMock()
+        mock_db.photos.return_value = [mock_visible, mock_hidden]
+        mock_osxphotos.PhotosDB.return_value = mock_db
+
+        library = PhotosLibrary()
+        videos = library.get_videos()
+
+        assert len(videos) == 1
+        assert videos[0].uuid == "visible"
+
+    @patch("video_converter.extractors.photos_extractor.osxphotos")
+    def test_get_videos_includes_hidden_when_requested(self, mock_osxphotos: MagicMock) -> None:
+        """Test that hidden videos are included when requested."""
+        mock_hidden = MagicMock()
+        mock_hidden.uuid = "hidden"
+        mock_hidden.original_filename = "hidden.mov"
+        mock_hidden.path = None
+        mock_hidden.date = None
+        mock_hidden.date_modified = None
+        mock_hidden.duration = 30.0
+        mock_hidden.favorite = False
+        mock_hidden.hidden = True
+        mock_hidden.iscloudasset = False
+        mock_hidden.location = None
+        mock_hidden.albums = []
+
+        mock_db = MagicMock()
+        mock_db.photos.return_value = [mock_hidden]
+        mock_osxphotos.PhotosDB.return_value = mock_db
+
+        library = PhotosLibrary()
+        videos = library.get_videos(include_hidden=True)
+
+        assert len(videos) == 1
+        assert videos[0].uuid == "hidden"
+
+    @patch("video_converter.extractors.photos_extractor.osxphotos")
+    def test_get_video_by_uuid_found(self, mock_osxphotos: MagicMock) -> None:
+        """Test get_video_by_uuid when video exists."""
+        mock_photo = MagicMock()
+        mock_photo.uuid = "target-uuid"
+        mock_photo.original_filename = "found.mov"
+        mock_photo.path = None
+        mock_photo.date = None
+        mock_photo.date_modified = None
+        mock_photo.duration = 45.0
+        mock_photo.favorite = False
+        mock_photo.hidden = False
+        mock_photo.iscloudasset = False
+        mock_photo.location = None
+        mock_photo.albums = []
+
+        mock_db = MagicMock()
+        mock_db.photos.return_value = [mock_photo]
+        mock_osxphotos.PhotosDB.return_value = mock_db
+
+        library = PhotosLibrary()
+        video = library.get_video_by_uuid("target-uuid")
+
+        assert video is not None
+        assert video.uuid == "target-uuid"
+        mock_db.photos.assert_called_with(uuid=["target-uuid"])
+
+    @patch("video_converter.extractors.photos_extractor.osxphotos")
+    def test_get_video_by_uuid_not_found(self, mock_osxphotos: MagicMock) -> None:
+        """Test get_video_by_uuid when video doesn't exist."""
+        mock_db = MagicMock()
+        mock_db.photos.return_value = []
+        mock_osxphotos.PhotosDB.return_value = mock_db
+
+        library = PhotosLibrary()
+        video = library.get_video_by_uuid("nonexistent-uuid")
+
+        assert video is None
+
+    @patch("video_converter.extractors.photos_extractor.osxphotos")
+    def test_close_resets_state(self, mock_osxphotos: MagicMock) -> None:
+        """Test that close resets internal state."""
+        mock_db = MagicMock()
+        mock_db.library_path = "/path"
+        mock_osxphotos.PhotosDB.return_value = mock_db
+
+        library = PhotosLibrary()
+        _ = library.db  # Initialize
+        library.check_permissions()
+
+        library.close()
+
+        # Internal state should be reset
+        assert library._db is None
+        assert library._initialized is False
+        assert library._permission_checked is False
+
+    @patch("video_converter.extractors.photos_extractor.osxphotos")
+    def test_context_manager(self, mock_osxphotos: MagicMock) -> None:
+        """Test context manager usage."""
+        mock_db = MagicMock()
+        mock_osxphotos.PhotosDB.return_value = mock_db
+
+        with PhotosLibrary() as library:
+            _ = library.db
+
+        # After context exit, library should be closed
+        assert library._db is None
+
+
+class TestGetPermissionInstructions:
+    """Tests for get_permission_instructions function."""
+
+    def test_returns_instructions_string(self) -> None:
+        """Test that get_permission_instructions returns a string."""
+        instructions = get_permission_instructions()
+        assert isinstance(instructions, str)
+        assert len(instructions) > 0
+
+    def test_contains_key_information(self) -> None:
+        """Test that instructions contain key information."""
+        instructions = get_permission_instructions()
+        assert "System Settings" in instructions
+        assert "Full Disk Access" in instructions
+        assert "Terminal" in instructions
+
+    def test_contains_quick_access_command(self) -> None:
+        """Test that instructions contain quick access command."""
+        instructions = get_permission_instructions()
+        assert "open" in instructions
+        assert "preference.security" in instructions


### PR DESCRIPTION
## Summary

- Implement `PhotosLibrary` class for accessing macOS Photos library via osxphotos
- Add comprehensive permission handling with user-friendly error messages
- Create `PhotosVideoInfo` dataclass for video metadata representation
- Support custom Photos library paths and lazy-loaded database connection

## Changes

### New Files
- `src/video_converter/extractors/photos_extractor.py` - Core Photos library integration
- `tests/unit/test_photos_extractor.py` - Comprehensive unit tests

### Modified Files
- `src/video_converter/extractors/__init__.py` - Export new classes

## Features Implemented

- [x] Create `PhotosLibrary` class with osxphotos integration
- [x] Initialize with default or custom Photos library path
- [x] Handle permission errors with helpful instructions
- [x] Cache PhotosDB instance for performance
- [x] Support filtering videos by date, albums, favorites, and hidden status
- [x] Provide context manager support for resource cleanup

## Test Plan

- [x] Unit tests for `PhotosVideoInfo` dataclass
- [x] Unit tests for `PhotosLibrary` class with mocked osxphotos
- [x] Tests for permission checking and error handling
- [x] Tests for video querying with various filters

Closes #13