### PR TITLE
feat(automation): implement service install/uninstall commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,53 @@ Session state is automatically saved to `~/.local/share/video_converter/sessions
 ### Enable Daily Automation
 
 ```bash
-video-converter install-service --time 03:00
+# Install with default schedule (daily at 3:00 AM)
+video-converter install-service
+
+# Install with custom time
+video-converter install-service --time 02:00
+
+# Install for weekly execution (every Monday at 4:00 AM)
+video-converter install-service --time 04:00 --weekday 1
+
+# Install with folder watching
+video-converter install-service --watch ~/Videos/Import
+
+# Combine time schedule with folder watching
+video-converter install-service --time 03:00 --watch ~/Videos/Import
+
+# Force reinstall if already installed
+video-converter install-service --force
+```
+
+### Check Service Status
+
+```bash
+video-converter status
+```
+
+Output example:
+```
+╭──────────────────────────────────────────────╮
+│         Video Converter Service              │
+├──────────────────────────────────────────────┤
+│  Status:     ○ Idle                          │
+│  Schedule:   Daily at 03:00                  │
+│  Plist:      ...aunchAgents/com.videocon...  │
+╰──────────────────────────────────────────────╯
+```
+
+### Remove Automation Service
+
+```bash
+# Uninstall service (with confirmation)
+video-converter uninstall-service
+
+# Uninstall without confirmation
+video-converter uninstall-service --yes
+
+# Uninstall and remove log files
+video-converter uninstall-service --remove-logs
 ```
 
 ## Usage
@@ -92,18 +138,19 @@ video-converter install-service --time 03:00
 video-converter <command> [options]
 
 Commands:
-  convert       Single file conversion
-  run           Batch conversion execution
-  status        Service status check
-  stats         Conversion statistics
-  config        Configuration management
-  install       Install automation service
-  uninstall     Remove automation service
+  convert           Single file conversion
+  run               Batch conversion execution
+  status            Service and conversion status
+  stats             Conversion statistics
+  setup             Initial setup wizard
+  install-service   Install launchd automation service
+  uninstall-service Remove launchd automation service
 
 Global Options:
   --config      Config file path
   --verbose     Detailed log output
   --quiet       Minimal output
+  --version     Show version
   --help        Show help
 ```
 

--- a/src/video_converter/__main__.py
+++ b/src/video_converter/__main__.py
@@ -1,6 +1,43 @@
 """CLI entrypoint for video-converter."""
 
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
 import click
+
+from video_converter.automation import ServiceManager, ServiceState
+
+
+def parse_time(time_str: str) -> tuple[int, int]:
+    """Parse time string in HH:MM format.
+
+    Args:
+        time_str: Time string in HH:MM format.
+
+    Returns:
+        Tuple of (hour, minute).
+
+    Raises:
+        click.BadParameter: If time format is invalid.
+    """
+    match = re.match(r"^(\d{1,2}):(\d{2})$", time_str)
+    if not match:
+        raise click.BadParameter(
+            f"Invalid time format: {time_str}. Use HH:MM format (e.g., 03:00)"
+        )
+
+    hour = int(match.group(1))
+    minute = int(match.group(2))
+
+    if not (0 <= hour <= 23):
+        raise click.BadParameter(f"Hour must be 0-23, got {hour}")
+    if not (0 <= minute <= 59):
+        raise click.BadParameter(f"Minute must be 0-59, got {minute}")
+
+    return hour, minute
 
 
 @click.group()
@@ -55,8 +92,43 @@ def run(mode: str, dry_run: bool) -> None:
 @main.command()
 def status() -> None:
     """Show service status."""
-    click.echo("Checking service status...")
-    # TODO: Implement status check
+    manager = ServiceManager()
+    service_status = manager.get_status()
+
+    click.echo()
+    click.echo("╭" + "─" * 46 + "╮")
+    click.echo("│" + "Video Converter Service".center(46) + "│")
+    click.echo("├" + "─" * 46 + "┤")
+
+    # Status line
+    if service_status.state == ServiceState.NOT_INSTALLED:
+        status_text = "✗ Not Installed"
+        status_style = "red"
+    elif service_status.state == ServiceState.INSTALLED_RUNNING:
+        status_text = f"● Running (PID: {service_status.pid})"
+        status_style = "green"
+    elif service_status.state == ServiceState.INSTALLED_ERROR:
+        status_text = f"✗ Error (exit: {service_status.last_exit_status})"
+        status_style = "red"
+    else:
+        status_text = "○ Idle"
+        status_style = "yellow"
+
+    click.echo(f"│  Status:     {click.style(status_text, fg=status_style):<35}│")
+
+    # Schedule line
+    if service_status.schedule:
+        click.echo(f"│  Schedule:   {service_status.schedule:<33}│")
+
+    # Plist path
+    if service_status.plist_path:
+        plist_display = str(service_status.plist_path)
+        if len(plist_display) > 33:
+            plist_display = "..." + plist_display[-30:]
+        click.echo(f"│  Plist:      {plist_display:<33}│")
+
+    click.echo("╰" + "─" * 46 + "╯")
+    click.echo()
 
 
 @main.command()
@@ -78,20 +150,175 @@ def setup() -> None:
 @main.command("install-service")
 @click.option(
     "--time",
+    "schedule_time",
     default="03:00",
-    help="Daily execution time (default: 03:00)",
+    help="Daily execution time in HH:MM format (default: 03:00)",
 )
-def install_service(time: str) -> None:
-    """Install launchd automation service."""
-    click.echo(f"Installing service to run daily at {time}...")
-    # TODO: Implement service installation
+@click.option(
+    "--weekday",
+    type=click.IntRange(0, 6),
+    default=None,
+    help="Day of week (0=Sunday, 6=Saturday). If not set, runs daily.",
+)
+@click.option(
+    "--watch",
+    "watch_paths",
+    multiple=True,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+    help="Folder to watch for new videos. Can be specified multiple times.",
+)
+@click.option(
+    "--run-now",
+    is_flag=True,
+    help="Run the service immediately after installation.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Force reinstall if service already exists.",
+)
+def install_service(
+    schedule_time: str,
+    weekday: int | None,
+    watch_paths: tuple[str, ...],
+    run_now: bool,
+    force: bool,
+) -> None:
+    """Install launchd automation service.
+
+    This command creates a launchd plist and loads it to enable
+    automatic video conversion on a schedule.
+
+    Examples:
+
+        # Install with default schedule (daily at 3:00 AM)
+        video-converter install-service
+
+        # Install to run at 2:00 AM
+        video-converter install-service --time 02:00
+
+        # Install to run every Monday at 4:00 AM
+        video-converter install-service --time 04:00 --weekday 1
+
+        # Install with folder watching
+        video-converter install-service --watch ~/Videos/Import
+
+        # Combine time schedule with folder watching
+        video-converter install-service --time 03:00 --watch ~/Videos/Import
+    """
+    # Parse time
+    try:
+        hour, minute = parse_time(schedule_time)
+    except click.BadParameter as e:
+        click.echo(click.style(f"Error: {e.message}", fg="red"), err=True)
+        sys.exit(1)
+
+    # Convert watch paths
+    watch_path_list = [Path(p) for p in watch_paths] if watch_paths else None
+
+    # Determine if we need a time schedule
+    schedule_hour: int | None = hour
+    if watch_path_list and not schedule_time:
+        schedule_hour = None
+
+    manager = ServiceManager()
+
+    click.echo(f"Installing service...")
+
+    result = manager.install(
+        hour=schedule_hour,
+        minute=minute,
+        weekday=weekday,
+        watch_paths=watch_path_list,
+        run_at_load=run_now,
+        force=force,
+    )
+
+    if result.success:
+        click.echo(click.style("✓ " + result.message, fg="green"))
+
+        if result.plist_path:
+            click.echo(f"  Plist: {result.plist_path}")
+
+        # Show log file locations
+        stdout_log, stderr_log = manager.get_log_paths()
+        click.echo(f"  Logs:  {stdout_log.parent}/")
+
+        if run_now:
+            click.echo()
+            click.echo("Service will run immediately.")
+    else:
+        click.echo(click.style(f"✗ {result.message}", fg="red"), err=True)
+        if result.error:
+            click.echo(click.style(f"  Error: {result.error}", fg="red"), err=True)
+        sys.exit(1)
 
 
 @main.command("uninstall-service")
-def uninstall_service() -> None:
-    """Remove launchd automation service."""
-    click.echo("Removing automation service...")
-    # TODO: Implement service removal
+@click.option(
+    "--remove-logs",
+    is_flag=True,
+    help="Also remove log files.",
+)
+@click.option(
+    "--yes", "-y",
+    is_flag=True,
+    help="Skip confirmation prompt.",
+)
+def uninstall_service(remove_logs: bool, yes: bool) -> None:
+    """Remove launchd automation service.
+
+    This command unloads the service from launchd and removes
+    the plist file.
+
+    Examples:
+
+        # Uninstall service (with confirmation)
+        video-converter uninstall-service
+
+        # Uninstall without confirmation
+        video-converter uninstall-service --yes
+
+        # Uninstall and remove log files
+        video-converter uninstall-service --remove-logs
+    """
+    manager = ServiceManager()
+    status = manager.get_status()
+
+    if not status.is_installed:
+        click.echo("Service is not installed.")
+        return
+
+    # Confirmation
+    if not yes:
+        click.echo(f"Service will be removed: {status.plist_path}")
+        if remove_logs:
+            click.echo("Log files will also be removed.")
+        if not click.confirm("Do you want to continue?"):
+            click.echo("Cancelled.")
+            return
+
+    click.echo("Uninstalling service...")
+
+    result = manager.uninstall(remove_logs=remove_logs)
+
+    if result.success:
+        click.echo(click.style("✓ " + result.message, fg="green"))
+    else:
+        click.echo(click.style(f"✗ {result.message}", fg="red"), err=True)
+        if result.error:
+            click.echo(click.style(f"  Error: {result.error}", fg="red"), err=True)
+        sys.exit(1)
+
+
+@main.command("service-status")
+def service_status() -> None:
+    """Show detailed service status.
+
+    Alias for 'status' command with more details about the launchd service.
+    """
+    # Delegate to status command
+    status()
 
 
 if __name__ == "__main__":

--- a/src/video_converter/automation/__init__.py
+++ b/src/video_converter/automation/__init__.py
@@ -16,8 +16,15 @@ from video_converter.automation.launchd import (
     generate_watch_plist,
     validate_plist_syntax,
 )
+from video_converter.automation.service_manager import (
+    ServiceManager,
+    ServiceResult,
+    ServiceState,
+    ServiceStatus,
+)
 
 __all__ = [
+    # launchd module
     "LaunchdSchedule",
     "LaunchdConfig",
     "LaunchdPlistGenerator",
@@ -28,4 +35,9 @@ __all__ = [
     "DEFAULT_PLIST_NAME",
     "DEFAULT_LOG_DIR",
     "SERVICE_LABEL",
+    # service_manager module
+    "ServiceManager",
+    "ServiceResult",
+    "ServiceState",
+    "ServiceStatus",
 ]

--- a/src/video_converter/automation/service_manager.py
+++ b/src/video_converter/automation/service_manager.py
@@ -1,0 +1,651 @@
+"""Service manager for macOS launchd automation.
+
+This module provides a high-level interface for installing, uninstalling,
+and managing the video converter launchd service on macOS.
+
+SDS Reference: SDS-A01-002
+SRS Reference: SRS-702 (Service Install/Uninstall)
+
+Example:
+    >>> from video_converter.automation.service_manager import ServiceManager
+    >>>
+    >>> manager = ServiceManager()
+    >>>
+    >>> # Install service to run daily at 3 AM
+    >>> result = manager.install(hour=3, minute=0)
+    >>> print(result.message)
+    >>>
+    >>> # Check service status
+    >>> status = manager.get_status()
+    >>> print(f"Installed: {status.is_installed}")
+    >>>
+    >>> # Uninstall service
+    >>> result = manager.uninstall()
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from video_converter.automation.launchd import (
+    DEFAULT_LAUNCH_AGENTS_DIR,
+    DEFAULT_LOG_DIR,
+    DEFAULT_PLIST_NAME,
+    SERVICE_LABEL,
+    LaunchdPlistGenerator,
+    validate_plist_syntax,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ServiceState(Enum):
+    """State of the launchd service."""
+
+    NOT_INSTALLED = "not_installed"
+    INSTALLED_IDLE = "installed_idle"
+    INSTALLED_RUNNING = "installed_running"
+    INSTALLED_ERROR = "installed_error"
+
+
+@dataclass
+class ServiceStatus:
+    """Status information for the launchd service.
+
+    Attributes:
+        state: Current state of the service.
+        is_installed: Whether the plist file exists.
+        is_loaded: Whether the service is loaded in launchd.
+        is_running: Whether the service is currently running.
+        pid: Process ID if running, None otherwise.
+        last_exit_status: Exit status from last run, None if never run.
+        plist_path: Path to the plist file.
+        schedule: Human-readable schedule description.
+        next_run: Estimated next run time, None if not scheduled.
+    """
+
+    state: ServiceState
+    is_installed: bool
+    is_loaded: bool
+    is_running: bool
+    pid: int | None = None
+    last_exit_status: int | None = None
+    plist_path: Path | None = None
+    schedule: str | None = None
+    next_run: datetime | None = None
+
+
+@dataclass
+class ServiceResult:
+    """Result of a service operation.
+
+    Attributes:
+        success: Whether the operation succeeded.
+        message: Human-readable result message.
+        error: Error message if failed, None otherwise.
+        plist_path: Path to the plist file, if applicable.
+    """
+
+    success: bool
+    message: str
+    error: str | None = None
+    plist_path: Path | None = None
+
+
+class ServiceManager:
+    """Manager for launchd service operations.
+
+    This class provides high-level operations for installing, uninstalling,
+    and querying the status of the video converter launchd service.
+
+    Attributes:
+        plist_path: Path to the launchd plist file.
+        log_dir: Directory for service log files.
+    """
+
+    def __init__(
+        self,
+        plist_path: Path | None = None,
+        log_dir: Path | None = None,
+    ) -> None:
+        """Initialize the service manager.
+
+        Args:
+            plist_path: Path to plist file. Defaults to LaunchAgents directory.
+            log_dir: Directory for log files.
+        """
+        self.plist_path = plist_path or (DEFAULT_LAUNCH_AGENTS_DIR / DEFAULT_PLIST_NAME)
+        self.log_dir = log_dir or DEFAULT_LOG_DIR
+        self._generator = LaunchdPlistGenerator(log_dir=self.log_dir)
+
+    def install(
+        self,
+        hour: int = 3,
+        minute: int = 0,
+        weekday: int | None = None,
+        watch_paths: list[Path] | None = None,
+        run_at_load: bool = False,
+        force: bool = False,
+    ) -> ServiceResult:
+        """Install the launchd service.
+
+        This method generates a plist file and loads it into launchd.
+        If the service is already installed, it will be updated if force=True.
+
+        Args:
+            hour: Hour to run (0-23). None for watch-only mode.
+            minute: Minute to run (0-59).
+            weekday: Day of week (0=Sunday). None for daily.
+            watch_paths: Folders to watch for changes.
+            run_at_load: Whether to run immediately when loaded.
+            force: If True, reinstall even if already installed.
+
+        Returns:
+            ServiceResult with success status and message.
+
+        Example:
+            >>> manager = ServiceManager()
+            >>> result = manager.install(hour=3, minute=0)
+            >>> if result.success:
+            ...     print("Service installed successfully")
+        """
+        # Check if already installed
+        status = self.get_status()
+        if status.is_installed and not force:
+            return ServiceResult(
+                success=False,
+                message="Service is already installed. Use --force to reinstall.",
+                error="Service already exists",
+                plist_path=self.plist_path,
+            )
+
+        # Unload existing service if loaded
+        if status.is_loaded:
+            unload_result = self._unload_service()
+            if not unload_result.success:
+                return unload_result
+
+        try:
+            # Generate plist
+            plist = self._generator.generate_plist(
+                hour=hour,
+                minute=minute,
+                weekday=weekday,
+                watch_paths=watch_paths,
+                run_at_load=run_at_load,
+            )
+
+            # Write plist to file
+            self._generator.write_plist(plist, self.plist_path)
+
+            # Validate plist syntax
+            if not validate_plist_syntax(self.plist_path):
+                return ServiceResult(
+                    success=False,
+                    message="Generated plist file is invalid",
+                    error="Plist validation failed",
+                    plist_path=self.plist_path,
+                )
+
+            # Load service
+            load_result = self._load_service()
+            if not load_result.success:
+                return load_result
+
+            # Build schedule description
+            schedule_desc = self._build_schedule_description(
+                hour, minute, weekday, watch_paths
+            )
+
+            logger.info(f"Service installed successfully: {schedule_desc}")
+            return ServiceResult(
+                success=True,
+                message=f"Service installed successfully. Schedule: {schedule_desc}",
+                plist_path=self.plist_path,
+            )
+
+        except Exception as e:
+            logger.exception("Failed to install service")
+            return ServiceResult(
+                success=False,
+                message="Failed to install service",
+                error=str(e),
+            )
+
+    def uninstall(self, remove_logs: bool = False) -> ServiceResult:
+        """Uninstall the launchd service.
+
+        This method unloads the service from launchd and removes the plist file.
+
+        Args:
+            remove_logs: If True, also remove log files.
+
+        Returns:
+            ServiceResult with success status and message.
+
+        Example:
+            >>> manager = ServiceManager()
+            >>> result = manager.uninstall()
+            >>> if result.success:
+            ...     print("Service uninstalled successfully")
+        """
+        status = self.get_status()
+
+        if not status.is_installed:
+            return ServiceResult(
+                success=True,
+                message="Service is not installed",
+            )
+
+        try:
+            # Unload service if loaded
+            if status.is_loaded:
+                unload_result = self._unload_service()
+                if not unload_result.success:
+                    logger.warning(f"Failed to unload service: {unload_result.error}")
+
+            # Remove plist file
+            if self.plist_path.exists():
+                self.plist_path.unlink()
+                logger.info(f"Removed plist file: {self.plist_path}")
+
+            # Remove logs if requested
+            if remove_logs and self.log_dir.exists():
+                for log_file in self.log_dir.glob("*.log"):
+                    log_file.unlink()
+                    logger.info(f"Removed log file: {log_file}")
+
+            return ServiceResult(
+                success=True,
+                message="Service uninstalled successfully",
+            )
+
+        except Exception as e:
+            logger.exception("Failed to uninstall service")
+            return ServiceResult(
+                success=False,
+                message="Failed to uninstall service",
+                error=str(e),
+            )
+
+    def get_status(self) -> ServiceStatus:
+        """Get the current status of the service.
+
+        Returns:
+            ServiceStatus with detailed status information.
+
+        Example:
+            >>> manager = ServiceManager()
+            >>> status = manager.get_status()
+            >>> print(f"Installed: {status.is_installed}")
+            >>> print(f"Running: {status.is_running}")
+        """
+        is_installed = self.plist_path.exists()
+        is_loaded = False
+        is_running = False
+        pid = None
+        last_exit_status = None
+        schedule = None
+
+        if is_installed:
+            # Query launchctl for service status
+            launchctl_info = self._get_launchctl_info()
+            is_loaded = launchctl_info.get("loaded", False)
+            pid = launchctl_info.get("pid")
+            last_exit_status = launchctl_info.get("last_exit_status")
+            is_running = pid is not None
+
+            # Parse schedule from plist
+            schedule = self._get_schedule_from_plist()
+
+        # Determine state
+        if not is_installed:
+            state = ServiceState.NOT_INSTALLED
+        elif is_running:
+            state = ServiceState.INSTALLED_RUNNING
+        elif last_exit_status is not None and last_exit_status != 0:
+            state = ServiceState.INSTALLED_ERROR
+        else:
+            state = ServiceState.INSTALLED_IDLE
+
+        return ServiceStatus(
+            state=state,
+            is_installed=is_installed,
+            is_loaded=is_loaded,
+            is_running=is_running,
+            pid=pid,
+            last_exit_status=last_exit_status,
+            plist_path=self.plist_path if is_installed else None,
+            schedule=schedule,
+        )
+
+    def start(self) -> ServiceResult:
+        """Manually start the service.
+
+        This triggers an immediate run of the service, regardless of schedule.
+
+        Returns:
+            ServiceResult with success status and message.
+        """
+        status = self.get_status()
+
+        if not status.is_installed:
+            return ServiceResult(
+                success=False,
+                message="Service is not installed",
+                error="Service not found",
+            )
+
+        if not status.is_loaded:
+            load_result = self._load_service()
+            if not load_result.success:
+                return load_result
+
+        try:
+            result = subprocess.run(
+                ["launchctl", "start", SERVICE_LABEL],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            if result.returncode == 0:
+                return ServiceResult(
+                    success=True,
+                    message="Service started successfully",
+                )
+            else:
+                return ServiceResult(
+                    success=False,
+                    message="Failed to start service",
+                    error=result.stderr.strip() or "Unknown error",
+                )
+
+        except Exception as e:
+            return ServiceResult(
+                success=False,
+                message="Failed to start service",
+                error=str(e),
+            )
+
+    def stop(self) -> ServiceResult:
+        """Stop the currently running service.
+
+        Returns:
+            ServiceResult with success status and message.
+        """
+        status = self.get_status()
+
+        if not status.is_running:
+            return ServiceResult(
+                success=True,
+                message="Service is not running",
+            )
+
+        try:
+            result = subprocess.run(
+                ["launchctl", "stop", SERVICE_LABEL],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            if result.returncode == 0:
+                return ServiceResult(
+                    success=True,
+                    message="Service stopped successfully",
+                )
+            else:
+                return ServiceResult(
+                    success=False,
+                    message="Failed to stop service",
+                    error=result.stderr.strip() or "Unknown error",
+                )
+
+        except Exception as e:
+            return ServiceResult(
+                success=False,
+                message="Failed to stop service",
+                error=str(e),
+            )
+
+    def _load_service(self) -> ServiceResult:
+        """Load the service into launchd.
+
+        Returns:
+            ServiceResult with success status.
+        """
+        try:
+            result = subprocess.run(
+                ["launchctl", "load", str(self.plist_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            if result.returncode == 0:
+                logger.info(f"Loaded service from {self.plist_path}")
+                return ServiceResult(
+                    success=True,
+                    message="Service loaded successfully",
+                )
+            else:
+                error_msg = result.stderr.strip() or "Unknown error"
+                logger.error(f"Failed to load service: {error_msg}")
+                return ServiceResult(
+                    success=False,
+                    message="Failed to load service",
+                    error=error_msg,
+                )
+
+        except Exception as e:
+            return ServiceResult(
+                success=False,
+                message="Failed to load service",
+                error=str(e),
+            )
+
+    def _unload_service(self) -> ServiceResult:
+        """Unload the service from launchd.
+
+        Returns:
+            ServiceResult with success status.
+        """
+        try:
+            result = subprocess.run(
+                ["launchctl", "unload", str(self.plist_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            if result.returncode == 0:
+                logger.info(f"Unloaded service from {self.plist_path}")
+                return ServiceResult(
+                    success=True,
+                    message="Service unloaded successfully",
+                )
+            else:
+                error_msg = result.stderr.strip() or "Unknown error"
+                logger.warning(f"Failed to unload service: {error_msg}")
+                return ServiceResult(
+                    success=False,
+                    message="Failed to unload service",
+                    error=error_msg,
+                )
+
+        except Exception as e:
+            return ServiceResult(
+                success=False,
+                message="Failed to unload service",
+                error=str(e),
+            )
+
+    def _get_launchctl_info(self) -> dict[str, Any]:
+        """Get service information from launchctl.
+
+        Returns:
+            Dictionary with service information.
+        """
+        info: dict[str, Any] = {"loaded": False}
+
+        try:
+            result = subprocess.run(
+                ["launchctl", "list"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            if result.returncode == 0:
+                for line in result.stdout.splitlines():
+                    if SERVICE_LABEL in line:
+                        info["loaded"] = True
+                        parts = line.split()
+                        if len(parts) >= 3:
+                            # Format: PID Status Label
+                            pid_str = parts[0]
+                            status_str = parts[1]
+
+                            if pid_str != "-":
+                                info["pid"] = int(pid_str)
+
+                            if status_str != "-":
+                                info["last_exit_status"] = int(status_str)
+
+                        break
+
+        except Exception as e:
+            logger.warning(f"Failed to get launchctl info: {e}")
+
+        return info
+
+    def _get_schedule_from_plist(self) -> str | None:
+        """Parse schedule description from plist file.
+
+        Returns:
+            Human-readable schedule description, or None.
+        """
+        if not self.plist_path.exists():
+            return None
+
+        try:
+            import plistlib
+
+            with self.plist_path.open("rb") as f:
+                plist = plistlib.load(f)
+
+            schedule_parts = []
+
+            # Check StartCalendarInterval
+            if "StartCalendarInterval" in plist:
+                interval = plist["StartCalendarInterval"]
+                hour = interval.get("Hour")
+                minute = interval.get("Minute", 0)
+                weekday = interval.get("Weekday")
+
+                if weekday is not None:
+                    days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+                    day_name = days[weekday] if 0 <= weekday <= 6 else str(weekday)
+                    schedule_parts.append(f"Weekly on {day_name}")
+                else:
+                    schedule_parts.append("Daily")
+
+                if hour is not None:
+                    schedule_parts.append(f"at {hour:02d}:{minute:02d}")
+
+            # Check WatchPaths
+            if "WatchPaths" in plist:
+                watch_count = len(plist["WatchPaths"])
+                schedule_parts.append(f"Watching {watch_count} folder(s)")
+
+            return " ".join(schedule_parts) if schedule_parts else None
+
+        except Exception as e:
+            logger.warning(f"Failed to parse schedule from plist: {e}")
+            return None
+
+    def _build_schedule_description(
+        self,
+        hour: int | None,
+        minute: int,
+        weekday: int | None,
+        watch_paths: list[Path] | None,
+    ) -> str:
+        """Build a human-readable schedule description.
+
+        Args:
+            hour: Hour to run.
+            minute: Minute to run.
+            weekday: Day of week.
+            watch_paths: Folders to watch.
+
+        Returns:
+            Human-readable schedule description.
+        """
+        parts = []
+
+        if hour is not None:
+            if weekday is not None:
+                days = ["Sunday", "Monday", "Tuesday", "Wednesday",
+                        "Thursday", "Friday", "Saturday"]
+                day_name = days[weekday] if 0 <= weekday <= 6 else str(weekday)
+                parts.append(f"Every {day_name} at {hour:02d}:{minute:02d}")
+            else:
+                parts.append(f"Daily at {hour:02d}:{minute:02d}")
+
+        if watch_paths:
+            paths_str = ", ".join(str(p) for p in watch_paths[:2])
+            if len(watch_paths) > 2:
+                paths_str += f" and {len(watch_paths) - 2} more"
+            parts.append(f"Watching: {paths_str}")
+
+        return "; ".join(parts) if parts else "No schedule"
+
+    def get_log_paths(self) -> tuple[Path, Path]:
+        """Get paths to stdout and stderr log files.
+
+        Returns:
+            Tuple of (stdout_path, stderr_path).
+        """
+        return (
+            self.log_dir / "stdout.log",
+            self.log_dir / "stderr.log",
+        )
+
+    def read_logs(self, lines: int = 50) -> dict[str, str]:
+        """Read recent log entries.
+
+        Args:
+            lines: Number of lines to read from each log file.
+
+        Returns:
+            Dictionary with 'stdout' and 'stderr' log contents.
+        """
+        stdout_path, stderr_path = self.get_log_paths()
+        logs = {"stdout": "", "stderr": ""}
+
+        for key, path in [("stdout", stdout_path), ("stderr", stderr_path)]:
+            if path.exists():
+                try:
+                    content = path.read_text()
+                    log_lines = content.splitlines()
+                    logs[key] = "\n".join(log_lines[-lines:])
+                except Exception as e:
+                    logs[key] = f"Error reading log: {e}"
+
+        return logs
+
+
+__all__ = [
+    "ServiceState",
+    "ServiceStatus",
+    "ServiceResult",
+    "ServiceManager",
+]

--- a/tests/unit/test_service_manager.py
+++ b/tests/unit/test_service_manager.py
@@ -1,0 +1,474 @@
+"""Unit tests for ServiceManager class."""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_converter.automation.launchd import SERVICE_LABEL
+from video_converter.automation.service_manager import (
+    ServiceManager,
+    ServiceResult,
+    ServiceState,
+    ServiceStatus,
+)
+
+
+class TestServiceStatus:
+    """Tests for ServiceStatus dataclass."""
+
+    def test_not_installed_status(self) -> None:
+        """Test status for uninstalled service."""
+        status = ServiceStatus(
+            state=ServiceState.NOT_INSTALLED,
+            is_installed=False,
+            is_loaded=False,
+            is_running=False,
+        )
+        assert status.state == ServiceState.NOT_INSTALLED
+        assert not status.is_installed
+        assert not status.is_loaded
+        assert not status.is_running
+        assert status.pid is None
+        assert status.plist_path is None
+
+    def test_installed_idle_status(self) -> None:
+        """Test status for installed but idle service."""
+        status = ServiceStatus(
+            state=ServiceState.INSTALLED_IDLE,
+            is_installed=True,
+            is_loaded=True,
+            is_running=False,
+            plist_path=Path("/test/path.plist"),
+            schedule="Daily at 03:00",
+        )
+        assert status.state == ServiceState.INSTALLED_IDLE
+        assert status.is_installed
+        assert status.is_loaded
+        assert not status.is_running
+        assert status.schedule == "Daily at 03:00"
+
+    def test_running_status(self) -> None:
+        """Test status for running service."""
+        status = ServiceStatus(
+            state=ServiceState.INSTALLED_RUNNING,
+            is_installed=True,
+            is_loaded=True,
+            is_running=True,
+            pid=12345,
+        )
+        assert status.state == ServiceState.INSTALLED_RUNNING
+        assert status.is_running
+        assert status.pid == 12345
+
+
+class TestServiceResult:
+    """Tests for ServiceResult dataclass."""
+
+    def test_success_result(self) -> None:
+        """Test successful result."""
+        result = ServiceResult(
+            success=True,
+            message="Service installed successfully",
+            plist_path=Path("/test/path.plist"),
+        )
+        assert result.success
+        assert result.error is None
+        assert result.plist_path is not None
+
+    def test_failure_result(self) -> None:
+        """Test failure result."""
+        result = ServiceResult(
+            success=False,
+            message="Failed to install service",
+            error="Permission denied",
+        )
+        assert not result.success
+        assert result.error == "Permission denied"
+
+
+class TestServiceManager:
+    """Tests for ServiceManager class."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Path:
+        """Create a temporary directory for tests."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    @pytest.fixture
+    def manager(self, temp_dir: Path) -> ServiceManager:
+        """Create a ServiceManager with temporary paths."""
+        plist_path = temp_dir / "test.plist"
+        log_dir = temp_dir / "logs"
+        return ServiceManager(plist_path=plist_path, log_dir=log_dir)
+
+    def test_initialization_default(self) -> None:
+        """Test manager with default settings."""
+        manager = ServiceManager()
+        assert manager.plist_path.name == "com.videoconverter.daily.plist"
+        assert "LaunchAgents" in str(manager.plist_path)
+
+    def test_initialization_custom_paths(self, temp_dir: Path) -> None:
+        """Test manager with custom paths."""
+        plist_path = temp_dir / "custom.plist"
+        log_dir = temp_dir / "custom_logs"
+
+        manager = ServiceManager(plist_path=plist_path, log_dir=log_dir)
+
+        assert manager.plist_path == plist_path
+        assert manager.log_dir == log_dir
+
+    def test_get_status_not_installed(self, manager: ServiceManager) -> None:
+        """Test status when service is not installed."""
+        status = manager.get_status()
+
+        assert status.state == ServiceState.NOT_INSTALLED
+        assert not status.is_installed
+        assert not status.is_loaded
+
+    @patch("subprocess.run")
+    def test_get_status_installed_idle(
+        self, mock_run: MagicMock, manager: ServiceManager
+    ) -> None:
+        """Test status when service is installed but idle."""
+        # Create plist file
+        plist = {
+            "Label": SERVICE_LABEL,
+            "StartCalendarInterval": {"Hour": 3, "Minute": 0},
+        }
+        with manager.plist_path.open("wb") as f:
+            plistlib.dump(plist, f)
+
+        # Mock launchctl list output (service loaded but not running)
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=f"-\t0\t{SERVICE_LABEL}\n",
+        )
+
+        status = manager.get_status()
+
+        assert status.is_installed
+        assert status.is_loaded
+        assert not status.is_running
+        assert status.state == ServiceState.INSTALLED_IDLE
+        assert "Daily" in (status.schedule or "")
+
+    @patch("subprocess.run")
+    def test_get_status_running(
+        self, mock_run: MagicMock, manager: ServiceManager
+    ) -> None:
+        """Test status when service is running."""
+        # Create plist file
+        plist = {"Label": SERVICE_LABEL}
+        manager.plist_path.parent.mkdir(parents=True, exist_ok=True)
+        with manager.plist_path.open("wb") as f:
+            plistlib.dump(plist, f)
+
+        # Mock launchctl list output (service running with PID)
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=f"12345\t0\t{SERVICE_LABEL}\n",
+        )
+
+        status = manager.get_status()
+
+        assert status.is_running
+        assert status.pid == 12345
+        assert status.state == ServiceState.INSTALLED_RUNNING
+
+    @patch("subprocess.run")
+    def test_install_success(
+        self, mock_run: MagicMock, manager: ServiceManager
+    ) -> None:
+        """Test successful service installation."""
+        # Mock all subprocess calls to succeed
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        result = manager.install(hour=3, minute=0)
+
+        assert result.success
+        assert manager.plist_path.exists()
+        assert result.plist_path == manager.plist_path
+
+        # Verify plist content
+        with manager.plist_path.open("rb") as f:
+            plist = plistlib.load(f)
+        assert plist["Label"] == SERVICE_LABEL
+        assert plist["StartCalendarInterval"]["Hour"] == 3
+
+    @patch("subprocess.run")
+    def test_install_already_installed(
+        self, mock_run: MagicMock, manager: ServiceManager
+    ) -> None:
+        """Test installation when service already exists."""
+        # Create existing plist
+        plist = {"Label": SERVICE_LABEL}
+        manager.plist_path.parent.mkdir(parents=True, exist_ok=True)
+        with manager.plist_path.open("wb") as f:
+            plistlib.dump(plist, f)
+
+        # Mock launchctl list to show service is loaded
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=f"-\t0\t{SERVICE_LABEL}\n",
+        )
+
+        result = manager.install(hour=3, minute=0, force=False)
+
+        assert not result.success
+        assert "already installed" in result.message
+
+    @patch("subprocess.run")
+    def test_install_force_reinstall(
+        self, mock_run: MagicMock, manager: ServiceManager
+    ) -> None:
+        """Test force reinstallation."""
+        # Create existing plist
+        plist = {"Label": SERVICE_LABEL}
+        manager.plist_path.parent.mkdir(parents=True, exist_ok=True)
+        with manager.plist_path.open("wb") as f:
+            plistlib.dump(plist, f)
+
+        # Mock all subprocess calls to succeed
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        result = manager.install(hour=4, minute=30, force=True)
+
+        assert result.success
+
+        # Verify new schedule
+        with manager.plist_path.open("rb") as f:
+            plist = plistlib.load(f)
+        assert plist["StartCalendarInterval"]["Hour"] == 4
+        assert plist["StartCalendarInterval"]["Minute"] == 30
+
+    @patch("subprocess.run")
+    def test_install_with_watch_paths(
+        self, mock_run: MagicMock, manager: ServiceManager, temp_dir: Path
+    ) -> None:
+        """Test installation with folder watching."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        watch_folder = temp_dir / "watch"
+        watch_folder.mkdir()
+
+        result = manager.install(hour=None, watch_paths=[watch_folder])
+
+        assert result.success
+
+        with manager.plist_path.open("rb") as f:
+            plist = plistlib.load(f)
+        assert "WatchPaths" in plist
+        # Compare resolved paths (macOS symlink /var -> /private/var)
+        resolved_watch = str(watch_folder.resolve())
+        assert any(resolved_watch in wp or wp in resolved_watch
+                   for wp in plist["WatchPaths"])
+
+    @patch("subprocess.run")
+    def test_uninstall_success(
+        self, mock_run: MagicMock, manager: ServiceManager
+    ) -> None:
+        """Test successful uninstallation."""
+        # Create plist file
+        plist = {"Label": SERVICE_LABEL}
+        manager.plist_path.parent.mkdir(parents=True, exist_ok=True)
+        with manager.plist_path.open("wb") as f:
+            plistlib.dump(plist, f)
+
+        # Mock launchctl calls
+        def mock_subprocess(cmd, **kwargs):
+            if "list" in cmd:
+                return MagicMock(
+                    returncode=0,
+                    stdout=f"-\t0\t{SERVICE_LABEL}\n",
+                )
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = mock_subprocess
+
+        result = manager.uninstall()
+
+        assert result.success
+        assert not manager.plist_path.exists()
+
+    def test_uninstall_not_installed(self, manager: ServiceManager) -> None:
+        """Test uninstallation when service is not installed."""
+        result = manager.uninstall()
+
+        assert result.success
+        assert "not installed" in result.message
+
+    @patch("subprocess.run")
+    def test_uninstall_with_logs(
+        self, mock_run: MagicMock, manager: ServiceManager
+    ) -> None:
+        """Test uninstallation with log removal."""
+        # Create plist and log files
+        plist = {"Label": SERVICE_LABEL}
+        manager.plist_path.parent.mkdir(parents=True, exist_ok=True)
+        with manager.plist_path.open("wb") as f:
+            plistlib.dump(plist, f)
+
+        manager.log_dir.mkdir(parents=True, exist_ok=True)
+        (manager.log_dir / "stdout.log").write_text("test log")
+        (manager.log_dir / "stderr.log").write_text("test error")
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        result = manager.uninstall(remove_logs=True)
+
+        assert result.success
+        assert not (manager.log_dir / "stdout.log").exists()
+        assert not (manager.log_dir / "stderr.log").exists()
+
+    @patch("subprocess.run")
+    def test_start_service(
+        self, mock_run: MagicMock, manager: ServiceManager
+    ) -> None:
+        """Test manual service start."""
+        # Create plist file
+        plist = {"Label": SERVICE_LABEL}
+        manager.plist_path.parent.mkdir(parents=True, exist_ok=True)
+        with manager.plist_path.open("wb") as f:
+            plistlib.dump(plist, f)
+
+        # Mock subprocess calls
+        def mock_subprocess(cmd, **kwargs):
+            if "list" in cmd:
+                return MagicMock(
+                    returncode=0,
+                    stdout=f"-\t0\t{SERVICE_LABEL}\n",
+                )
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = mock_subprocess
+
+        result = manager.start()
+
+        assert result.success
+
+    def test_start_not_installed(self, manager: ServiceManager) -> None:
+        """Test start when service is not installed."""
+        result = manager.start()
+
+        assert not result.success
+        assert "not installed" in result.message
+
+    @patch("subprocess.run")
+    def test_stop_service(
+        self, mock_run: MagicMock, manager: ServiceManager
+    ) -> None:
+        """Test service stop."""
+        # Create plist file
+        plist = {"Label": SERVICE_LABEL}
+        manager.plist_path.parent.mkdir(parents=True, exist_ok=True)
+        with manager.plist_path.open("wb") as f:
+            plistlib.dump(plist, f)
+
+        # Mock subprocess calls to show running service
+        def mock_subprocess(cmd, **kwargs):
+            if "list" in cmd:
+                return MagicMock(
+                    returncode=0,
+                    stdout=f"12345\t0\t{SERVICE_LABEL}\n",
+                )
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = mock_subprocess
+
+        result = manager.stop()
+
+        assert result.success
+
+    def test_stop_not_running(self, manager: ServiceManager) -> None:
+        """Test stop when service is not running."""
+        result = manager.stop()
+
+        assert result.success
+        assert "not running" in result.message
+
+    def test_get_log_paths(self, manager: ServiceManager) -> None:
+        """Test getting log file paths."""
+        stdout_path, stderr_path = manager.get_log_paths()
+
+        assert stdout_path.name == "stdout.log"
+        assert stderr_path.name == "stderr.log"
+        assert stdout_path.parent == manager.log_dir
+
+    def test_read_logs_empty(self, manager: ServiceManager) -> None:
+        """Test reading logs when files don't exist."""
+        logs = manager.read_logs()
+
+        assert logs["stdout"] == ""
+        assert logs["stderr"] == ""
+
+    def test_read_logs_with_content(self, manager: ServiceManager) -> None:
+        """Test reading logs with content."""
+        manager.log_dir.mkdir(parents=True, exist_ok=True)
+
+        stdout_content = "Line 1\nLine 2\nLine 3"
+        stderr_content = "Error 1\nError 2"
+
+        (manager.log_dir / "stdout.log").write_text(stdout_content)
+        (manager.log_dir / "stderr.log").write_text(stderr_content)
+
+        logs = manager.read_logs()
+
+        assert "Line 1" in logs["stdout"]
+        assert "Error 1" in logs["stderr"]
+
+
+class TestScheduleDescription:
+    """Tests for schedule description building."""
+
+    @pytest.fixture
+    def manager(self) -> ServiceManager:
+        """Create a ServiceManager for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield ServiceManager(
+                plist_path=Path(tmpdir) / "test.plist",
+                log_dir=Path(tmpdir) / "logs",
+            )
+
+    def test_daily_schedule_description(self, manager: ServiceManager) -> None:
+        """Test description for daily schedule."""
+        desc = manager._build_schedule_description(
+            hour=3, minute=0, weekday=None, watch_paths=None
+        )
+        assert "Daily" in desc
+        assert "03:00" in desc
+
+    def test_weekly_schedule_description(self, manager: ServiceManager) -> None:
+        """Test description for weekly schedule."""
+        desc = manager._build_schedule_description(
+            hour=9, minute=30, weekday=1, watch_paths=None
+        )
+        assert "Monday" in desc
+        assert "09:30" in desc
+
+    def test_watch_paths_description(self, manager: ServiceManager) -> None:
+        """Test description with watch paths."""
+        desc = manager._build_schedule_description(
+            hour=None,
+            minute=0,
+            weekday=None,
+            watch_paths=[Path("/path/to/folder")],
+        )
+        assert "Watching" in desc
+
+    def test_combined_schedule_description(self, manager: ServiceManager) -> None:
+        """Test description with both schedule and watch paths."""
+        desc = manager._build_schedule_description(
+            hour=3,
+            minute=0,
+            weekday=None,
+            watch_paths=[Path("/path/to/folder")],
+        )
+        assert "Daily" in desc
+        assert "Watching" in desc


### PR DESCRIPTION
## Summary

- Add `ServiceManager` class for launchctl operations (install, uninstall, start, stop, status)
- Implement `install-service` CLI command with comprehensive options
- Implement `uninstall-service` CLI command with cleanup options
- Update `status` command to show service information

## Changes

### ServiceManager Class (`automation/service_manager.py`)
- `install()`: Generate plist and load service with launchctl
- `uninstall()`: Unload service and remove plist file
- `start()`/`stop()`: Manual service control
- `get_status()`: Query detailed service status from launchctl
- `read_logs()`: Read recent log entries

### CLI Commands (`__main__.py`)
- `install-service`:
  - `--time HH:MM`: Schedule time (default: 03:00)
  - `--weekday 0-6`: Day of week for weekly execution
  - `--watch PATH`: Folder to monitor for new videos
  - `--run-now`: Run immediately after installation
  - `--force`: Force reinstall if already exists
- `uninstall-service`:
  - `--remove-logs`: Also remove log files
  - `--yes/-y`: Skip confirmation prompt
- `status`: Enhanced with service status display

### Tests
- Added 28 unit tests for ServiceManager class
- All tests passing (65 total with launchd tests)

### Documentation
- Updated README.md with service command examples

## Test plan

- [x] Unit tests for ServiceManager (28 tests)
- [x] Unit tests for launchd module (37 tests)
- [x] Manual testing on macOS
  - [x] Install service with default settings
  - [x] Install service with custom time
  - [x] Install service with folder watching
  - [x] Check service status
  - [x] Uninstall service

Closes #34