### PR TITLE
feat(utils): implement command execution utility for FFmpeg and ExifTool

### DIFF
--- a/src/video_converter/utils/__init__.py
+++ b/src/video_converter/utils/__init__.py
@@ -10,7 +10,12 @@ from video_converter.utils.command_runner import (
     CommandNotFoundError,
     CommandResult,
     CommandRunner,
+    CommandTimeoutError,
+    ExifToolRunner,
     FFprobeRunner,
+    run_command,
+    run_exiftool,
+    run_ffprobe,
 )
 from video_converter.utils.progress_parser import (
     FFmpegProgress,
@@ -18,11 +23,20 @@ from video_converter.utils.progress_parser import (
 )
 
 __all__ = [
+    # Command execution
     "CommandResult",
     "CommandRunner",
     "CommandNotFoundError",
     "CommandExecutionError",
+    "CommandTimeoutError",
+    # Specialized runners
     "FFprobeRunner",
+    "ExifToolRunner",
+    # Convenience functions
+    "run_command",
+    "run_ffprobe",
+    "run_exiftool",
+    # Progress parsing
     "FFmpegProgress",
     "FFmpegProgressParser",
 ]

--- a/src/video_converter/utils/command_runner.py
+++ b/src/video_converter/utils/command_runner.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 import shutil
 import subprocess
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -39,11 +40,43 @@ class CommandResult:
 
 
 class CommandNotFoundError(Exception):
-    """Raised when required external command is not found."""
+    """Raised when required external command is not found.
+
+    This exception provides helpful installation instructions for common tools.
+
+    Attributes:
+        command: The command that was not found.
+    """
+
+    INSTALL_HINTS = {
+        "ffmpeg": "Install with: brew install ffmpeg",
+        "ffprobe": "Install with: brew install ffmpeg",
+        "exiftool": "Install with: brew install exiftool",
+    }
 
     def __init__(self, command: str) -> None:
         self.command = command
-        super().__init__(f"Command '{command}' not found. Please install it first.")
+        hint = self.INSTALL_HINTS.get(command, "")
+        msg = f"Command '{command}' not found."
+        if hint:
+            msg += f" {hint}"
+        super().__init__(msg)
+
+
+class CommandTimeoutError(Exception):
+    """Raised when command execution exceeds timeout.
+
+    Attributes:
+        command: The command that timed out.
+        timeout: The timeout value in seconds.
+    """
+
+    def __init__(self, command: str, timeout: float) -> None:
+        self.command = command
+        self.timeout = timeout
+        super().__init__(
+            f"Command '{command}' timed out after {timeout:.1f} seconds."
+        )
 
 
 class CommandExecutionError(Exception):
@@ -185,6 +218,131 @@ class CommandRunner:
                 returncode=process.returncode or 0,
                 stdout=stdout.decode("utf-8", errors="replace"),
                 stderr=stderr.decode("utf-8", errors="replace"),
+            )
+
+            if check and not cmd_result.success:
+                raise CommandExecutionError(
+                    command_name, cmd_result.returncode, cmd_result.stderr
+                )
+
+            return cmd_result
+
+        except FileNotFoundError as e:
+            raise CommandNotFoundError(command_name) from e
+
+    def run_with_callback(
+        self,
+        args: list[str],
+        on_output: Callable[[str], None],
+        *,
+        timeout: float | None = 600.0,
+        check: bool = False,
+        read_stderr: bool = True,
+    ) -> CommandResult:
+        """Run a command with real-time output streaming.
+
+        This method allows monitoring command output in real-time, which is
+        useful for tracking progress of long-running operations like video
+        encoding.
+
+        Args:
+            args: Command and arguments to execute.
+            on_output: Callback function called for each output line.
+            timeout: Maximum time to wait for command (seconds).
+            check: If True, raise exception on non-zero exit code.
+            read_stderr: If True, read from stderr (FFmpeg outputs to stderr).
+
+        Returns:
+            CommandResult containing the final execution result.
+
+        Raises:
+            CommandNotFoundError: If the command is not found.
+            CommandExecutionError: If check=True and command fails.
+            CommandTimeoutError: If command times out.
+
+        Example:
+            >>> def on_progress(line: str):
+            ...     if "frame=" in line:
+            ...         print(f"Progress: {line}")
+            >>> runner = CommandRunner()
+            >>> result = runner.run_with_callback(
+            ...     ["ffmpeg", "-i", "input.mp4", "output.mp4"],
+            ...     on_output=on_progress,
+            ...     read_stderr=True,
+            ... )
+        """
+        command_name = args[0] if args else ""
+        self.ensure_command_exists(command_name)
+
+        stdout_lines: list[str] = []
+        stderr_lines: list[str] = []
+
+        try:
+            process = subprocess.Popen(
+                args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE if read_stderr else subprocess.DEVNULL,
+                text=True,
+                bufsize=1,
+            )
+
+            import selectors
+            import time
+
+            sel = selectors.DefaultSelector()
+            if process.stdout:
+                sel.register(process.stdout, selectors.EVENT_READ)
+            if read_stderr and process.stderr:
+                sel.register(process.stderr, selectors.EVENT_READ)
+
+            start_time = time.monotonic()
+
+            while True:
+                # Check timeout
+                if timeout is not None:
+                    elapsed = time.monotonic() - start_time
+                    if elapsed >= timeout:
+                        process.kill()
+                        process.wait()
+                        raise CommandTimeoutError(command_name, timeout)
+
+                    remaining = timeout - elapsed
+                else:
+                    remaining = None
+
+                events = sel.select(timeout=min(remaining, 0.1) if remaining else 0.1)
+
+                for key, _ in events:
+                    line = key.fileobj.readline()  # type: ignore[union-attr]
+                    if line:
+                        line = line.rstrip("\n\r")
+                        if key.fileobj == process.stdout:
+                            stdout_lines.append(line)
+                        else:
+                            stderr_lines.append(line)
+                        on_output(line)
+
+                # Check if process has finished
+                if process.poll() is not None:
+                    # Read remaining output
+                    if process.stdout:
+                        for line in process.stdout:
+                            line = line.rstrip("\n\r")
+                            stdout_lines.append(line)
+                            on_output(line)
+                    if read_stderr and process.stderr:
+                        for line in process.stderr:
+                            line = line.rstrip("\n\r")
+                            stderr_lines.append(line)
+                            on_output(line)
+                    break
+
+            sel.close()
+
+            cmd_result = CommandResult(
+                returncode=process.returncode or 0,
+                stdout="\n".join(stdout_lines),
+                stderr="\n".join(stderr_lines),
             )
 
             if check and not cmd_result.success:
@@ -349,3 +507,292 @@ class FFprobeRunner:
             return result.success and not result.stderr.strip()
         except (CommandNotFoundError, CommandExecutionError):
             return False
+
+
+class ExifToolRunner:
+    """Specialized runner for ExifTool commands.
+
+    Provides convenient methods for extracting and modifying metadata
+    from media files using ExifTool.
+
+    Example:
+        >>> runner = ExifToolRunner()
+        >>> metadata = runner.read_metadata(Path("video.mp4"))
+        >>> print(metadata.get("CreateDate"))
+        '2024:01:15 10:30:00'
+    """
+
+    EXIFTOOL_CMD = "exiftool"
+
+    def __init__(self, command_runner: CommandRunner | None = None) -> None:
+        """Initialize ExifTool runner.
+
+        Args:
+            command_runner: CommandRunner instance to use. If None, creates a new one.
+        """
+        self._runner = command_runner or CommandRunner()
+
+    def read_metadata(
+        self,
+        path: Path,
+        *,
+        timeout: float = 30.0,
+        tags: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Read metadata from a file.
+
+        Args:
+            path: Path to the file.
+            timeout: Maximum time to wait (seconds).
+            tags: Specific tags to read. If None, reads all tags.
+
+        Returns:
+            Dictionary containing metadata key-value pairs.
+
+        Raises:
+            CommandNotFoundError: If ExifTool is not installed.
+            CommandExecutionError: If reading fails.
+            FileNotFoundError: If the file doesn't exist.
+        """
+        if not path.exists():
+            raise FileNotFoundError(f"File not found: {path}")
+
+        args = [self.EXIFTOOL_CMD, "-j", "-n"]
+
+        if tags:
+            args.extend(f"-{tag}" for tag in tags)
+
+        args.append(str(path))
+
+        result = self._runner.run(args, timeout=timeout, check=True)
+        data = json.loads(result.stdout)
+
+        # ExifTool returns a list with one dict per file
+        return data[0] if data else {}
+
+    async def read_metadata_async(
+        self,
+        path: Path,
+        *,
+        timeout: float = 30.0,
+        tags: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Read metadata from a file asynchronously.
+
+        Args:
+            path: Path to the file.
+            timeout: Maximum time to wait (seconds).
+            tags: Specific tags to read. If None, reads all tags.
+
+        Returns:
+            Dictionary containing metadata key-value pairs.
+        """
+        if not path.exists():
+            raise FileNotFoundError(f"File not found: {path}")
+
+        args = [self.EXIFTOOL_CMD, "-j", "-n"]
+
+        if tags:
+            args.extend(f"-{tag}" for tag in tags)
+
+        args.append(str(path))
+
+        result = await self._runner.run_async(args, timeout=timeout, check=True)
+        data = json.loads(result.stdout)
+
+        return data[0] if data else {}
+
+    def write_metadata(
+        self,
+        path: Path,
+        metadata: dict[str, Any],
+        *,
+        timeout: float = 30.0,
+        overwrite_original: bool = True,
+    ) -> bool:
+        """Write metadata to a file.
+
+        Args:
+            path: Path to the file.
+            metadata: Dictionary of tag-value pairs to write.
+            timeout: Maximum time to wait (seconds).
+            overwrite_original: If True, modify file in place without backup.
+
+        Returns:
+            True if metadata was written successfully.
+
+        Raises:
+            CommandNotFoundError: If ExifTool is not installed.
+            CommandExecutionError: If writing fails.
+            FileNotFoundError: If the file doesn't exist.
+        """
+        if not path.exists():
+            raise FileNotFoundError(f"File not found: {path}")
+
+        args = [self.EXIFTOOL_CMD]
+
+        if overwrite_original:
+            args.append("-overwrite_original")
+
+        for tag, value in metadata.items():
+            args.append(f"-{tag}={value}")
+
+        args.append(str(path))
+
+        result = self._runner.run(args, timeout=timeout, check=True)
+        return result.success
+
+    def copy_metadata(
+        self,
+        source: Path,
+        dest: Path,
+        *,
+        timeout: float = 30.0,
+        overwrite_original: bool = True,
+        all_tags: bool = True,
+    ) -> bool:
+        """Copy metadata from source file to destination file.
+
+        Args:
+            source: Source file to copy metadata from.
+            dest: Destination file to copy metadata to.
+            timeout: Maximum time to wait (seconds).
+            overwrite_original: If True, modify dest in place without backup.
+            all_tags: If True, copy all tags. Otherwise, only common tags.
+
+        Returns:
+            True if metadata was copied successfully.
+
+        Raises:
+            CommandNotFoundError: If ExifTool is not installed.
+            FileNotFoundError: If either file doesn't exist.
+        """
+        if not source.exists():
+            raise FileNotFoundError(f"Source file not found: {source}")
+        if not dest.exists():
+            raise FileNotFoundError(f"Destination file not found: {dest}")
+
+        args = [self.EXIFTOOL_CMD]
+
+        if overwrite_original:
+            args.append("-overwrite_original")
+
+        if all_tags:
+            args.append("-TagsFromFile")
+            args.append(str(source))
+            args.append("-all:all")
+        else:
+            args.append("-TagsFromFile")
+            args.append(str(source))
+
+        args.append(str(dest))
+
+        result = self._runner.run(args, timeout=timeout, check=True)
+        return result.success
+
+    def quick_check(self, path: Path, timeout: float = 10.0) -> bool:
+        """Quickly check if ExifTool can read a file.
+
+        Args:
+            path: Path to the file.
+            timeout: Maximum time to wait (seconds).
+
+        Returns:
+            True if the file is readable, False otherwise.
+        """
+        if not path.exists():
+            return False
+
+        args = [self.EXIFTOOL_CMD, "-ver", str(path)]
+
+        try:
+            result = self._runner.run(args, timeout=timeout)
+            return result.success
+        except (CommandNotFoundError, CommandExecutionError):
+            return False
+
+
+# Convenience functions for simple use cases
+
+
+def run_command(
+    args: list[str],
+    *,
+    timeout: float | None = 60.0,
+    check: bool = False,
+    on_output: Callable[[str], None] | None = None,
+) -> CommandResult:
+    """Run an external command.
+
+    This is a convenience function that creates a CommandRunner instance
+    and executes the command.
+
+    Args:
+        args: Command and arguments to execute.
+        timeout: Maximum time to wait for command (seconds).
+        check: If True, raise exception on non-zero exit code.
+        on_output: Optional callback for real-time output streaming.
+
+    Returns:
+        CommandResult containing the execution result.
+
+    Example:
+        >>> result = run_command(["ffmpeg", "-version"])
+        >>> print(result.stdout)
+    """
+    runner = CommandRunner()
+    if on_output is not None:
+        return runner.run_with_callback(args, on_output, timeout=timeout, check=check)
+    return runner.run(args, timeout=timeout, check=check)
+
+
+def run_ffprobe(
+    path: str | Path,
+    *,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Run FFprobe on a video file and return parsed JSON output.
+
+    This is a convenience function for quick video analysis.
+
+    Args:
+        path: Path to the video file.
+        timeout: Maximum time to wait (seconds).
+
+    Returns:
+        Dictionary containing video information.
+
+    Example:
+        >>> info = run_ffprobe("video.mp4")
+        >>> print(info["streams"][0]["codec_name"])
+        'h264'
+    """
+    runner = FFprobeRunner()
+    return runner.probe(Path(path), timeout=timeout)
+
+
+def run_exiftool(
+    path: str | Path,
+    *,
+    timeout: float = 30.0,
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """Run ExifTool on a file and return metadata.
+
+    This is a convenience function for quick metadata extraction.
+
+    Args:
+        path: Path to the file.
+        timeout: Maximum time to wait (seconds).
+        tags: Specific tags to read. If None, reads all tags.
+
+    Returns:
+        Dictionary containing metadata key-value pairs.
+
+    Example:
+        >>> metadata = run_exiftool("video.mp4")
+        >>> print(metadata.get("CreateDate"))
+        '2024:01:15 10:30:00'
+    """
+    runner = ExifToolRunner()
+    return runner.read_metadata(Path(path), timeout=timeout, tags=tags)


### PR DESCRIPTION
## Summary
- Add CommandTimeoutError exception for proper timeout handling
- Implement ExifToolRunner class for metadata extraction and modification
- Add run_with_callback method for real-time output streaming during video encoding
- Add convenience functions: run_command, run_ffprobe, run_exiftool
- Enhance CommandNotFoundError with installation hints for common tools (ffmpeg, exiftool)
- Add comprehensive unit tests for all new features (18 new tests)

## Changes
- `src/video_converter/utils/command_runner.py`: Extended with new classes and functions
- `src/video_converter/utils/__init__.py`: Export new classes and functions
- `tests/unit/test_command_runner.py`: Added tests for all new functionality

## Test plan
- [x] All 36 unit tests pass
- [x] Linting passes with ruff
- [ ] Manual testing with actual FFmpeg and ExifTool commands

Closes #3