### PR TITLE
chore: unify version to single source using importlib.metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+#### Version Unification (#172)
+- **Unified version source** to use `pyproject.toml` as single source of truth via `importlib.metadata`
+  - `__init__.py` now loads version from package metadata
+  - `config.py` imports `__version__` instead of hardcoding version
+  - `build_app.sh` reads version dynamically via Python
+  - Removed version field from `config/default.json` (determined at runtime)
+- **Version updated** from scattered values (0.1.0, 0.2.0.0, 0.3.0, 1.0.0) to unified `0.2.1.0`
+- **Added version consistency tests** to ensure all version references remain synchronized
+
 #### Photos Convert Orchestrator Integration (#171)
 - **Refactored Photos batch conversion** to use `orchestrator.run()` instead of direct `converter.convert()` calls
   - Enables concurrent processing via `--max-concurrent` option (1-8 workers)

--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,4 @@
 {
-  "version": "0.1.0.0",
   "encoding": {
     "mode": "hardware",
     "quality": 45,

--- a/packaging/macos/build_app.sh
+++ b/packaging/macos/build_app.sh
@@ -28,7 +28,6 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 # Build configuration
 APP_NAME="Video Converter"
-APP_VERSION="0.3.0"
 BUNDLE_ID="com.github.kcenon.videoconverter"
 SPEC_FILE="${SCRIPT_DIR}/video_converter.spec"
 DIST_DIR="${PROJECT_ROOT}/dist"
@@ -108,6 +107,10 @@ check_dependencies() {
         pip3 install -e "${PROJECT_ROOT}[gui]"
     fi
     print_success "video_converter package found"
+
+    # Get version from package
+    APP_VERSION=$(python3 -c "from video_converter import __version__; print(__version__)")
+    print_success "App version: ${APP_VERSION}"
 
     # Check for code signing tools (if signing is enabled)
     if $DO_SIGN; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "video-converter"
-version = "0.2.0.0"
+version = "0.2.1.0"
 description = "Automated H.264 to H.265 video conversion for macOS with Photos library integration"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/video_converter/__init__.py
+++ b/src/video_converter/__init__.py
@@ -1,4 +1,10 @@
 """Video Converter - Automated H.264 to H.265 conversion for macOS."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("video-converter")
+except PackageNotFoundError:
+    __version__ = "0.0.0.dev"
+
 __author__ = "Video Converter Team"

--- a/src/video_converter/core/config.py
+++ b/src/video_converter/core/config.py
@@ -35,6 +35,8 @@ from pydantic_settings import (
 )
 from pydantic_settings.sources import JsonConfigSettingsSource
 
+from video_converter import __version__
+
 # Default paths
 DEFAULT_CONFIG_DIR = Path.home() / ".config" / "video_converter"
 DEFAULT_CONFIG_FILE = DEFAULT_CONFIG_DIR / "config.json"
@@ -227,7 +229,7 @@ class Config(BaseSettings):
         extra="ignore",
     )
 
-    version: str = "1.0.0"
+    version: str = Field(default_factory=lambda: __version__)
     encoding: EncodingConfig = Field(default_factory=EncodingConfig)
     paths: PathsConfig = Field(default_factory=PathsConfig)
     automation: AutomationConfig = Field(default_factory=AutomationConfig)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -250,9 +250,7 @@ class TestConfigEnvironmentOverride:
         config = Config.load(force_reload=True)
         assert config.encoding.quality == 80
 
-    def test_processing_max_concurrent_override(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_processing_max_concurrent_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test processing max_concurrent environment override."""
         monkeypatch.setenv("VIDEO_CONVERTER_PROCESSING__MAX_CONCURRENT", "4")
         config = Config.load(force_reload=True)
@@ -334,9 +332,7 @@ class TestConfigReset:
         # Should be different instance after reset
         assert id(config2) != config1_id
 
-    def test_reset_allows_new_env_override(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_reset_allows_new_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that reset allows new environment override."""
         config1 = Config.load()
         assert config1.encoding.mode == "hardware"
@@ -480,3 +476,35 @@ class TestConfigWithFolder:
         result = config.to_dict()
         assert "folder" in result
 
+
+class TestVersionConsistency:
+    """Tests for version consistency across the codebase."""
+
+    def test_version_from_package_metadata(self) -> None:
+        """Test that __version__ is loaded from package metadata."""
+        from video_converter import __version__
+
+        assert __version__ is not None
+        assert len(__version__) > 0
+        # Version should follow semantic versioning pattern (x.y.z or x.y.z.w)
+        parts = __version__.split(".")
+        assert len(parts) >= 3, f"Version '{__version__}' should have at least 3 parts"
+
+    def test_config_version_matches_package_version(self) -> None:
+        """Test that Config.version matches package __version__."""
+        from video_converter import __version__
+
+        config = Config.load()
+        assert config.version == __version__
+
+    def test_cli_version_output(self) -> None:
+        """Test that CLI --version outputs correct version."""
+        from click.testing import CliRunner
+
+        from video_converter import __version__
+        from video_converter.__main__ import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == 0
+        assert __version__ in result.output


### PR DESCRIPTION
## Summary

- Unify version information scattered across 5 locations to use `pyproject.toml` as the single source
- Use `importlib.metadata.version()` for runtime version synchronization

## Changes

| File | Before | After |
|------|--------|-------|
| `pyproject.toml:7` | `0.2.0.0` | `0.2.1.0` (Single source) |
| `src/video_converter/__init__.py:3` | `0.1.0` (hardcoded) | `importlib.metadata.version()` |
| `config/default.json:2` | `0.1.0.0` | Removed (runtime determined) |
| `src/video_converter/core/config.py:230` | `1.0.0` (hardcoded) | Imports `__version__` |
| `packaging/macos/build_app.sh:31` | `0.3.0` (hardcoded) | Reads from Python |

## Test Plan

- [x] Verify `video-converter --version` outputs `0.2.1.0`
- [x] Verify `Config.version` matches `__version__`
- [x] Added `TestVersionConsistency` tests with 3 test cases
- [x] All 1493 unit tests pass

## Related Issue

Fixes #172
Part of #169 (Phase 2: Schema/Version Consistency)