### PR TITLE
release: Publish v0.3.0.0 with unreleased changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0.0] - 2025-12-24
 
 ### Changed
 
@@ -341,6 +341,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Product Requirements Document (PRD)
 - Architecture documentation
 
-[Unreleased]: https://github.com/kcenon/video_converter/compare/v0.2.0.0...HEAD
+[Unreleased]: https://github.com/kcenon/video_converter/compare/v0.3.0.0...HEAD
+[0.3.0.0]: https://github.com/kcenon/video_converter/compare/v0.2.0.0...v0.3.0.0
 [0.2.0.0]: https://github.com/kcenon/video_converter/compare/v0.1.0.0...v0.2.0.0
 [0.1.0.0]: https://github.com/kcenon/video_converter/releases/tag/v0.1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "video-converter"
-version = "0.2.1.0"
+version = "0.3.0.0"
 description = "Automated H.264 to H.265 video conversion for macOS with Photos library integration"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

- Bump version from 0.2.1.0 to 0.3.0.0
- Update CHANGELOG.md with release date 2025-12-24
- Add version comparison links for v0.3.0.0

## Changes Included in v0.3.0.0

### Changed
- Extract Magic Numbers to Constants Module (#176)
- Extended Config Schema for VMAF, HDR, and Processing Settings (#173)
- Version Unification (#172)
- Photos Convert Orchestrator Integration (#171)
- CLI Convert Command Orchestrator Integration (#170)

### Fixed
- CI Build Fixes (#181) - osxphotos macOS-only marker
- PySide6 6.10 Compatibility and Test Fixes (#169)

### Added
- macOS App Packaging (#145)
- GUI: Photos Library Browser (#143)
- GUI: Menubar App Integration (#142)
- GUI: Drag and Drop Support (#141)
- GUI: Settings Persistence (#140)
- GUI: Main Window UI (#138)
- GUI Integration Tests (#160)
- Accessibility Tests (#161)
- UpdateService (#159)

## Test Plan

- [x] All unit tests pass (1722 passed)
- [ ] Integration tests pass
- [ ] Version displays correctly in CLI and GUI

## Checklist

- [x] CHANGELOG.md updated with correct release date
- [x] pyproject.toml version updated to 0.3.0.0
- [x] All unit tests pass (80%+ coverage)
- [ ] Git tag v0.3.0.0 created (after merge)
- [ ] GitHub Release created (after merge)

Closes #186