### PR TITLE
fix(ci): allow workflow_dispatch to trigger docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
           path: site
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary

- Allow manual `workflow_dispatch` trigger to deploy documentation to GitHub Pages
- Previously, only `push` events to `main` would trigger deployment

## Background

When GitHub Pages deployment fails, it's useful to manually re-trigger the workflow.
However, the previous condition only allowed deployment on `push` events, causing
`workflow_dispatch` triggers to skip the deploy job.

## Changes

```yaml
# Before
if: github.event_name == 'push' && github.ref == 'refs/heads/main'

# After
if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
```

## Test Plan

- [x] Verify workflow syntax is valid
- [ ] Test manual workflow_dispatch deployment after merge