### PR TITLE
fix(cli): deduplicate symlink and firmlink paths in scan output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Broken symlink handling and OS error count reporting
   - Path filtering, size filtering, and keyboard interrupt handling
 
+#### Scan Command Display Improvements (#228)
+- **Symlink and firmlink deduplication** - Prevents duplicate entries in scan output
+  - Same file accessed via different paths appears only once
+  - Handles macOS firmlinks (`/System/Volumes/Data` prefix normalization)
+  - Accurate file count and storage totals (no double-counting)
+- **Full path display** - Shows complete directory paths in scan output
+  - Removed 60-character path truncation
+  - Rich Table automatically wraps long paths for readability
+
 ### Changed
 
 #### CI/CD Configuration Improvements (#219)


### PR DESCRIPTION
## Summary

- Deduplicates symlink and macOS firmlink paths in scan output
- Removes path truncation to show full directory paths
- Fixes double-counting of files accessible via multiple paths

## Changes

- Add `seen_resolved_paths` set to track already-processed paths
- Add `normalize_macos_path()` function to handle macOS firmlinks
- Remove `/System/Volumes/Data` prefix for consistent path display
- Remove 60-character path truncation (Rich Table handles wrapping)
- Store normalized paths to avoid duplicates in output

## Test plan

- [x] Unit tests pass (9 tests in `test_scan_cmd.py`)
- [x] Manual verification: `video-converter scan --path /` shows no duplicates
- [x] Paths display in full without truncation
- [x] Largest files list shows each file only once

## Before/After

**Before:**
```
│ ...Data/Volumes/T5 EVO/4K Instagram/4K Stogram/pldance/reels │   543 │  3.26 GB │
│ /Volumes/T5 EVO/4K Instagram/4K Stogram/pldance/reels        │   543 │  3.26 GB │  ← DUPLICATE
Found 3456 video(s) / 178.17 GB (inflated due to duplicates)
```

**After:**
```
│ /Volumes/T5 EVO/4K Instagram/4K Stogram/pldance/reels     │   543 │  3.26 GB │
Found 1268 video(s) / 6.61 GB (accurate count)
```

Fixes #228